### PR TITLE
Fixed typo in Readme usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ assert(not pcall( ftp_path.currentdir, ftp_path ) )
 
 local path = require "path"
 path.each("./*", function(P, mode)
-  if mode == 'directrory' then 
+  if mode == 'directory' then 
     path.rmdir(P)
   else
     path.remove(P)


### PR DESCRIPTION
Just fixed a little typo in the readme example snippet.
Should be `if mode == directory then ... end`.

Regards,
Roland.
